### PR TITLE
исправление производительности на режимах с синусами/волнами

### DIFF
--- a/CUBE_Gyver/CUBE_Gyver.ino
+++ b/CUBE_Gyver/CUBE_Gyver.ino
@@ -223,8 +223,8 @@ void sinusFill() {
     clearCube();
     if (++pos > 10) pos = 0;
     for (uint8_t i = 0; i < 8; i++) {
+      uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
       for (uint8_t j = 0; j < 8; j++) {
-        int8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
         for (uint8_t y = 0; y < sinZ; y++) {
           setVoxel(i, y, j);
         }
@@ -244,8 +244,8 @@ void sinusThin() {
     clearCube();
     if (++pos > 10) pos = 0;
     for (uint8_t i = 0; i < 8; i++) {
+      uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
       for (uint8_t j = 0; j < 8; j++) {
-        int8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
         setVoxel(i, sinZ, j);
       }
     }

--- a/CUBE_Gyver_v2/CUBE_Gyver_v2.ino
+++ b/CUBE_Gyver_v2/CUBE_Gyver_v2.ino
@@ -646,8 +646,8 @@ void sinusFill() {
     clearCube();
     if (++pos > 10) pos = 0;
     for (uint8_t i = 0; i < 8; i++) {
+      uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
       for (uint8_t j = 0; j < 8; j++) {
-        int8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
         for (uint8_t y = 0; y < sinZ; y++) {
           setVoxel(i, y, j);
         }
@@ -667,8 +667,8 @@ void sinusThin() {
     clearCube();
     if (++pos > 10) pos = 0;
     for (uint8_t i = 0; i < 8; i++) {
+      uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
       for (uint8_t j = 0; j < 8; j++) {
-        int8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
         setVoxel(i, sinZ, j);
       }
     }


### PR DESCRIPTION
Смотрел видео с кубом и увидел что волны подлагивают. Решил исправить. Путем нехитрых манипуляций выяснил что компилятор как то плохо оптимизировал.

В итоге разница оказалась существенной:
```
time old_sinusFill 1260
time new_sinusFill 4
```

Тестировал на таком примере (тк нет куба)
```C++
void sinusFill();
void old_sinusFill();

uint8_t pos = 10;

using fnc_ptr = void (*)(void);

void checkTime(fnc_ptr fnc, const char* fnc_name) {
  Serial.print("start ");
  Serial.println(fnc_name);
  auto start = micros();
  fnc();
  auto end = micros();
  Serial.print("time ");
  Serial.print(fnc_name);
  Serial.print(": ");
  Serial.println(end - start);
}

void setup() {
  Serial.begin(9600);
  
  checkTime(sinusFill, "new_sinusFill");
  checkTime(old_sinusFill, "old_sinusFill");  
}

void loop() { }

void setVoxel(uint8_t first, uint8_t second, uint8_t third) {  }

void old_sinusFill() {
  for (uint8_t i = 0; i < 8; i++) {
    for (uint8_t j = 0; j < 8; j++) {
      uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);
      for (uint8_t y = 0; y < sinZ; y++) {
        setVoxel(i, y, j);
      }
    }
  }
}

void sinusFill() {

  for (uint8_t i = 0; i < 8; i++) {

    uint8_t sinZ = 4 + ((float)sin((float)(i + pos) / 2) * 2);

    for (uint8_t j = 0; j < 8; j++) {
      for (uint8_t y = 0; y < sinZ; y++) {
        setVoxel(i, y, j);
      }
    }
  }
}
```